### PR TITLE
db-migrate job should run portal:migrate instead of winter:up

### DIFF
--- a/charts/curator/templates/job-db-migrate.yaml
+++ b/charts/curator/templates/job-db-migrate.yaml
@@ -43,7 +43,7 @@ spec:
           subPath: {{ $key }}.php
         {{- end }}
         {{- end }}
-        command: [ "php", "artisan", "winter:up"]
+        command: [ "php", "artisan", "portal:migrate"]
         env:
           {{- include "env.environment" . | indent 10 -}}
           {{ range $key, $value := .Values.curator.env }}
@@ -72,3 +72,4 @@ spec:
         configMap:
           name: {{ include "curator.fullname" . }}-config
       {{- end }}
+


### PR DESCRIPTION
The db-migrate Kubernetes Job in the Helm chart is currently executing the wrong Artisan command. Line 46 in charts/curator/templates/job-db-migrate.yaml runs winter:up but should be running portal:migrate instead.

https://github.com/InterWorks/curator-helm/issues/10