### PR TITLE
MariaDB Load balancing

### DIFF
--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -1,6 +1,6 @@
 # curator
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.08-01](https://img.shields.io/badge/AppVersion-2025.08--01-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.08-03](https://img.shields.io/badge/AppVersion-2025.08--03-informational?style=flat-square)
 
 A Helm chart for Curator in a Container in Kubernetes
 
@@ -50,6 +50,7 @@ A Helm chart for Curator in a Container in Kubernetes
 | mariadbOperator.database.name | string | `"production"` | database to create |
 | mariadbOperator.enabled | bool | `true` |  |
 | mariadbOperator.mariaDbName | string | `"curator-mariadb"` | Name of existing mariadb resource |
+| mariadbOperator.mariadbEndpoint | string | `""` | Endpoint to connect to mariadb, if not set it will use the mariaDbName as the hostname |
 | mariadbOperator.user.grantOption | bool | `false` | grantOption for the user |
 | mariadbOperator.user.host | string | `"%"` | allowable login hosts for the user |
 | mariadbOperator.user.maxUserConnections | int | `100` | maximum number of connections for the user |

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -1,6 +1,6 @@
 {{ define "env.environment" }}
 - name: DB_HOST
-  value: {{ .Values.mariadbOperator.mariaDbName | default "curator-mariadb" }}-primary
+  value: {{ .Values.mariadbOperator.mariadbEndpoint | default .Values.mariadbOperator.mariaDbName }}
 - name: DB_DATABASE
   value: {{ .Values.mariadbOperator.database.name | default .Values.environment }}
 - name: DB_USERNAME

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -235,6 +235,8 @@ mariadbOperator:
   enabled: true
   # -- Name of existing mariadb resource
   mariaDbName: "curator-mariadb"
+  # -- Endpoint to connect to mariadb, if not set it will use the mariaDbName as the hostname
+  mariadbEndpoint: ""
   ## Database to connect to
   database:
     # -- database to create


### PR DESCRIPTION
Previously the only connected mariadb pod was the 'primary' one. Since we use galera for multi-master replication we're able to use any of the pods for both reads and writes. This allows us to use the generic mariadb endpoint rather than the primary specific one