### PR TITLE
feat(helm-chart): add Sentry environment variables

### DIFF
--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -31,7 +31,7 @@ A Helm chart for Curator in a Container in Kubernetes
 | curator.startupProbe.initialDelaySeconds | int | `10` |  |
 | curator.startupProbe.periodSeconds | int | `10` |  |
 | curator.startupProbe.timeoutSeconds | int | `5` | Timeout for probe |
-| environment | string | `"prod"` | Environment type (prod, qa, or dev). Used for cache prefix, database defaults, resource sizing, and SENTRY_ENVIRONMENT |
+| environment | string | `"prod"` | Environment type (prod, qa, or dev). Used for cache prefix, database defaults, and resource sizing |
 | fullnameOverride | string | `""` | Overrides the full name of the chart, default is the name of the release |
 | image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/interworks","repository":"curator","tag":"latest"}` | Image configuration |
 | image.pullPolicy | string | `"IfNotPresent"` | Image Pull Policy |

--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -1,6 +1,6 @@
-# Curator
+# curator
 
-![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.08-03](https://img.shields.io/badge/AppVersion-2025.08--03-informational?style=flat-square)
+![Version: 2.4.1](https://img.shields.io/badge/Version-2.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2025.08-03](https://img.shields.io/badge/AppVersion-2025.08--03-informational?style=flat-square)
 
 A Helm chart for Curator in a Container in Kubernetes
 
@@ -26,6 +26,7 @@ A Helm chart for Curator in a Container in Kubernetes
 | curator.livenessProbe.failureThreshold | int | `3` | Number of failures before pod is failed |
 | curator.livenessProbe.periodSeconds | int | `10` | Period to wait between checks |
 | curator.livenessProbe.timeoutSeconds | int | `15` | Timeout for probe |
+| curator.sentry.dsn | string | `""` | Sentry Laravel DSN for error reporting |
 | curator.startupProbe.failureThreshold | int | `10` |  |
 | curator.startupProbe.initialDelaySeconds | int | `10` |  |
 | curator.startupProbe.periodSeconds | int | `10` |  |

--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -31,7 +31,7 @@ A Helm chart for Curator in a Container in Kubernetes
 | curator.startupProbe.initialDelaySeconds | int | `10` |  |
 | curator.startupProbe.periodSeconds | int | `10` |  |
 | curator.startupProbe.timeoutSeconds | int | `5` | Timeout for probe |
-| environment | string | `"prod"` | Required to be either prod, qa, or dev |
+| environment | string | `"prod"` | Environment type (prod, qa, or dev). Used for cache prefix, database defaults, resource sizing, and SENTRY_ENVIRONMENT |
 | fullnameOverride | string | `""` | Overrides the full name of the chart, default is the name of the release |
 | image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/interworks","repository":"curator","tag":"latest"}` | Image configuration |
 | image.pullPolicy | string | `"IfNotPresent"` | Image Pull Policy |

--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -27,6 +27,7 @@ A Helm chart for Curator in a Container in Kubernetes
 | curator.livenessProbe.periodSeconds | int | `10` | Period to wait between checks |
 | curator.livenessProbe.timeoutSeconds | int | `15` | Timeout for probe |
 | curator.sentry.dsn | string | `""` | Sentry Laravel DSN for error reporting |
+| curator.sentry.environment | string | `""` | Sentry Laravel environment name, defaults to the Helm release name if not set |
 | curator.startupProbe.failureThreshold | int | `10` |  |
 | curator.startupProbe.initialDelaySeconds | int | `10` |  |
 | curator.startupProbe.periodSeconds | int | `10` |  |

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -26,6 +26,12 @@
 - name: S3_REGION
   value: {{ .Values.persistence.s3.region | default .Values.environment }}
 {{- end }}
+{{- if .Values.curator.sentry.dsn }}
+- name: SENTRY_LARAVEL_DSN
+  value: {{ .Values.curator.sentry.dsn }}
+{{- end }}
+- name: SENTRY_ENVIRONMENT
+  value: {{ .Values.environment }}
 {{- range .Values.curator.envFromSecret }}
 - name: {{ .name }}
   valueFrom:

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -31,7 +31,7 @@
   value: {{ .Values.curator.sentry.dsn }}
 {{- end }}
 - name: SENTRY_ENVIRONMENT
-  value: {{ .Release.Name }}
+  value: {{ .Values.sentry.environment }}
 {{- range .Values.curator.envFromSecret }}
 - name: {{ .name }}
   valueFrom:

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -31,7 +31,7 @@
   value: {{ .Values.curator.sentry.dsn }}
 {{- end }}
 - name: SENTRY_ENVIRONMENT
-  value: {{ .Values.environment }}
+  value: {{ .Release.Name }}
 {{- range .Values.curator.envFromSecret }}
 - name: {{ .name }}
   valueFrom:

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -31,7 +31,7 @@
   value: {{ .Values.curator.sentry.dsn }}
 {{- end }}
 - name: SENTRY_ENVIRONMENT
-  value: {{ .Values.sentry.environment }}
+  value: {{ .Values.curator.sentry.environment | default .Release.Name }}
 {{- range .Values.curator.envFromSecret }}
 - name: {{ .name }}
   valueFrom:

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -189,8 +189,8 @@ curator:
   sentry:
     # -- Sentry Laravel DSN for error reporting
     dsn: ""
-    # -- Sentry Laravel environment name
-    environment: {{ .Release.Name }}
+    # -- Sentry Laravel environment name, defaults to the Helm release name if not set
+    environment: ""
   cache:
     # -- cache prefix
     prefix: ""

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -1,8 +1,7 @@
 # -- Number of replicas to deploy
 replicaCount: ~
 
-# -- Environment type that this chart is being deployed to
-# -- Required to be either prod, qa, or dev
+# -- Environment type (prod, qa, or dev). Used for cache prefix, database defaults, resource sizing, and SENTRY_ENVIRONMENT
 environment: prod # needs to be either dev, qa, or prod
 
 # -- Image configuration

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -189,6 +189,8 @@ curator:
   sentry:
     # -- Sentry Laravel DSN for error reporting
     dsn: ""
+    # -- Sentry Laravel environment name
+    environment: {{ .Release.Name }}
   cache:
     # -- cache prefix
     prefix: ""

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -187,6 +187,9 @@ curator:
   # -- environment variables to set in the container
   env: {}
     # KEY: VALUE
+  sentry:
+    # -- Sentry Laravel DSN for error reporting
+    dsn: ""
   cache:
     # -- cache prefix
     prefix: ""

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -1,7 +1,7 @@
 # -- Number of replicas to deploy
 replicaCount: ~
 
-# -- Environment type (prod, qa, or dev). Used for cache prefix, database defaults, resource sizing, and SENTRY_ENVIRONMENT
+# -- Environment type (prod, qa, or dev). Used for cache prefix, database defaults, and resource sizing
 environment: prod # needs to be either dev, qa, or prod
 
 # -- Image configuration


### PR DESCRIPTION
## Summary
- Adds `SENTRY_LARAVEL_DSN` and `SENTRY_ENVIRONMENT` env vars to all workloads (deployment, cronjob, jobs) via `_env.tpl`
- `SENTRY_LARAVEL_DSN` is conditionally set from the new `curator.sentry.dsn` Helm value (mapped from the `SENTRY_CURATOR_DSN` GitHub variable at deploy time)
- `SENTRY_ENVIRONMENT` is always set, derived from the existing `.Values.environment` field (`dev`, `qa`, or `prod`)