### PR TITLE
feat(helm/curator): add /healthz readiness probe for Curator pods

### DIFF
--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -24,21 +24,27 @@ A Helm chart for Curator in a Container in Kubernetes
 | curator.env | object | `{}` | environment variables to set in the container |
 | curator.envFromSecret | list | `[]` | read environment variables from a secret |
 | curator.livenessProbe.failureThreshold | int | `3` | Number of failures before pod is failed |
+| curator.livenessProbe.path | string | `"/ping"` | Endpoint the probe hits; keep it cheap and dependency-free |
 | curator.livenessProbe.periodSeconds | int | `10` | Period to wait between checks |
 | curator.livenessProbe.timeoutSeconds | int | `15` | Timeout for probe |
+| curator.readinessProbe.failureThreshold | int | `3` | Number of failures before the pod is removed from the Service endpoints |
+| curator.readinessProbe.path | string | `"/healthz"` | Endpoint the probe hits; /healthz verifies the database is reachable |
+| curator.readinessProbe.periodSeconds | int | `10` | Period to wait between checks |
+| curator.readinessProbe.timeoutSeconds | int | `15` | Timeout for probe |
 | curator.sentry.dsn | string | `""` | Sentry Laravel DSN for error reporting |
 | curator.sentry.environment | string | `""` | Sentry Laravel environment name, defaults to the Helm release name if not set |
 | curator.startupProbe.failureThreshold | int | `10` |  |
 | curator.startupProbe.initialDelaySeconds | int | `10` |  |
+| curator.startupProbe.path | string | `"/ping"` | Endpoint the probe hits; keep it cheap and dependency-free |
 | curator.startupProbe.periodSeconds | int | `10` |  |
 | curator.startupProbe.timeoutSeconds | int | `5` | Timeout for probe |
 | environment | string | `"prod"` | Environment type (prod, qa, or dev). Used for cache prefix, database defaults, and resource sizing |
 | fullnameOverride | string | `""` | Overrides the full name of the chart, default is the name of the release |
-| image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/interworks","repository":"curator","tag":"latest"}` | Image configuration |
+| image | object | `{"pullPolicy":"IfNotPresent","registry":"ghcr.io/interworks","repository":"curator","tag":"latest@sha256:117a4e3b90a012670d36c6fe4c25f14c37d5049aa0d153bbd7c70b134179b53d"}` | Image configuration |
 | image.pullPolicy | string | `"IfNotPresent"` | Image Pull Policy |
 | image.registry | string | `"ghcr.io/interworks"` | Registry URL |
 | image.repository | string | `"curator"` | Repository name |
-| image.tag | string | `"latest"` | Tag Name, overrides the default appVersion in Chart.yaml |
+| image.tag | string | `"latest@sha256:117a4e3b90a012670d36c6fe4c25f14c37d5049aa0d153bbd7c70b134179b53d"` | Tag Name, overrides the default appVersion in Chart.yaml |
 | ingress.className | string | `nil` | Ingress Class Name |
 | ingress.enabled | bool | `true` | Control for ingress |
 | ingress.hosts | list | `[]` | Ingress hosts configuration |

--- a/charts/curator/templates/deployment.yaml
+++ b/charts/curator/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
               protocol: TCP
           startupProbe:
             httpGet:
-              path: /ping
+              path: {{ .Values.curator.startupProbe.path | default "/ping" }}
               port: http
             initialDelaySeconds: {{ .Values.curator.startupProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.curator.startupProbe.periodSeconds }}
@@ -57,8 +57,15 @@ spec:
             periodSeconds: {{ .Values.curator.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.curator.livenessProbe.timeoutSeconds }}
             httpGet:
-              path: /ping
+              path: {{ .Values.curator.livenessProbe.path | default "/ping" }}
               port: http
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.curator.readinessProbe.path | default "/healthz" }}
+              port: http
+            failureThreshold: {{ .Values.curator.readinessProbe.failureThreshold }}
+            periodSeconds: {{ .Values.curator.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.curator.readinessProbe.timeoutSeconds }}
           env:
             {{- include "env.environment" . | indent 12 }}
             {{- range $key, $value := .Values.curator.env }}

--- a/charts/curator/tests/deployment.yaml
+++ b/charts/curator/tests/deployment.yaml
@@ -15,3 +15,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: ghcr.io/interworks/curator:latest
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /ping

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -200,6 +200,8 @@ curator:
     existingSecret: curator-auth
   ## Delayed startup probe to allow MariaDB to start
   startupProbe:
+    # -- Endpoint the probe hits; keep it cheap and dependency-free
+    path: /ping
     ## -- Seconds until initial probe
     initialDelaySeconds: 10
     ## -- Period to wait before next check
@@ -208,11 +210,26 @@ curator:
     failureThreshold: 10
     # -- Timeout for probe
     timeoutSeconds: 5
-  ## Probe to check for pod liveness
+  ## Probe to check for pod liveness. Keep this dependency-free (/ping) -- a database-aware
+  ## endpoint here would fail every pod at once during a DB blip and trigger mass restarts.
   livenessProbe:
+    # -- Endpoint the probe hits; keep it cheap and dependency-free
+    path: /ping
     # -- Period to wait between checks
     periodSeconds: 10
     # -- Number of failures before pod is failed
+    failureThreshold: 3
+    # -- Timeout for probe
+    timeoutSeconds: 15
+  ## Probe to gate traffic on real readiness. /healthz verifies database connectivity and
+  ## returns 503 when the DB is unreachable, so a failing pod is pulled from the Service
+  ## endpoints (traffic stops) rather than restarted.
+  readinessProbe:
+    # -- Endpoint the probe hits; /healthz verifies the database is reachable
+    path: /healthz
+    # -- Period to wait between checks
+    periodSeconds: 10
+    # -- Number of failures before the pod is removed from the Service endpoints
     failureThreshold: 3
     # -- Timeout for probe
     timeoutSeconds: 15


### PR DESCRIPTION
## Summary

Curator gained a new `/healthz` endpoint that performs a real health check
(database connectivity -> 200 healthy / 503 unhealthy). This wires it into the
Helm chart as a Kubernetes **readiness** probe so the platform stops routing
traffic to a pod whose database is unreachable, without killing the pod.

## What changed

- `templates/deployment.yaml`
  - Added a `readinessProbe` (httpGet `/healthz`) to the curator-server container.
  - Templated the `httpGet.path` on all three probes through values so the
    endpoint is configurable per-release (defaults preserve current behavior).
- `values.yaml`
  - New `curator.readinessProbe` block: `path: /healthz`, `periodSeconds: 10`,
    `failureThreshold: 3`, `timeoutSeconds: 15`.
  - Added `path` to `curator.startupProbe` (`/ping`) and `curator.livenessProbe`
    (`/ping`) with explanatory comments.
- `README.md` -- regenerated helm-docs rows for the new/changed values.
- `tests/deployment.yaml` -- assert readiness probe hits `/healthz` and liveness
  stays on `/ping`.

## Why readiness, not liveness

`/healthz` depends on the database. Per the Kubernetes probe guidance
(https://kubernetes.io/docs/concepts/workloads/pods/probes/), a dependency-aware
check belongs on readiness:

- **Readiness failure** removes the pod IP from the Service EndpointSlice --
  traffic stops, pod keeps running, rejoins when the DB recovers.
- **Liveness failure** restarts the container. A DB-aware liveness check would
  fail on every replica simultaneously during a DB blip and restart the whole
  fleet at once (cascading outage). So liveness/startup stay on `/ping`.

The `/healthz` endpoint returns 403 to non-private source IPs by design, so it is
only reachable by in-cluster kubelet probes (pod IP, private range), never from
the public ingress.

## Compatibility / rollout

- The startup and liveness probe paths are templated with their current defaults
  (`/ping`), so those are unchanged. The **readiness probe is a new, unconditional
  default** -- it is not opt-in. Any pod created from chart 2.6.0 gets a readiness
  probe hitting `/healthz`, regardless of the Curator image version it runs.
- This introduces a coupling: chart >= 2.6.0 requires the running image to serve a
  200 on `/healthz`. An image without a working `/healthz` (older than the endpoint,
  or a rollback to one) would fail readiness and never become Ready.
- Verified this is safe for the current fleet: `/healthz` shipped 2026-05-31
  (curator PR #224), and every deployed SaaS install is pinned to `2026.07-01`
  (prod) or `2026.07-02-rc.3` (dev/qa) -- both ~2 months newer than the endpoint.
  No current customer runs an image without it, so the rollout is safe today. The
  residual risk is limited to a future rollback to a pre-2026.06 image.
- Severity note: on a rolling update the old pods stay Ready (they don't carry the
  new probe) and PDB `minAvailable: 1` holds, so a bad case is a stalled rollout,
  not an outage. A true outage would require a fresh install or full restart with
  no old pods to fall back on.
- semantic-release will cut chart **2.6.0** on merge.
- Follow-up (separate iac-interworks change): bump the pinned chart `version:` in
  each customer `*-helmrelease.yaml` from 2.5.0 -> 2.6.0 to roll it out. Flux
  reconciles the new readiness probe automatically once the version is bumped.

## Testing

- `helm-unittest` (tests/deployment.yaml): readiness probe renders `/healthz`,
  liveness renders `/ping`.
- Post-deploy sanity check on a dev site:
  `kubectl exec deploy/<release>-server -- \
     curl -s -o /dev/null -w '%{http_code}' localhost:8080/healthz`
  Expect `200` when the DB is up. Confirm `kubectl get pods` shows the pod Ready.

## Pre-merge verification to run locally

    helm lint charts/curator
    helm template charts/curator | grep -A4 readinessProbe
    helm unittest charts/curator
    helm-docs --chart-search-root=charts