### PR TITLE
ci: add verify flag to bypass verification for git install

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -17,7 +17,7 @@ jobs:
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1 --verify=false
 
       - name: Run helm unit tests
         run: helm unittest charts/curator

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -16,8 +16,11 @@ jobs:
       - name: Set up tools via mise
         uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
 
+      - name: Confirm Helm install
+        run: helm version --short
+        
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1 --verify=false
+        run: helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest --version v1.1.1
 
       - name: Run helm unit tests
         run: helm unittest charts/curator

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -18,9 +18,9 @@ jobs:
 
       - name: Confirm Helm install
         run: helm version --short
-        
+
       - name: Install helm-unittest plugin
-        run: helm plugin install --verify=false https://github.com/helm-unittest/helm-unittest --version v1.1.1
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
 
       - name: Run helm unit tests
         run: helm unittest charts/curator


### PR DESCRIPTION
git repos don't support verification via GPG keys. The alternative option is to install it via OCI however that package is much bigger.