### PR TITLE
docs: document the release-automation GitHub App

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Tool versions are pinned in [`mise.toml`](./mise.toml). Install them with:
 mise install
 ```
 
-This provides `helm` and `helm-docs` at the versions CI uses.
+This provides `helm`, `helm-docs`, and `node` at the versions CI uses.
 
 ## Commits and releases
 
@@ -26,6 +26,33 @@ lands on `main` must follow that format (`feat:`, `fix:`, `docs:`, `chore:`,
   publishes the `curator-<version>` release + `index.yaml`.
 
 You never edit the chart `version` by hand — release-please owns it.
+
+## Release automation (GitHub App)
+
+release-please runs with a token minted from a **GitHub App**, not the default
+`GITHUB_TOKEN`. This is deliberate: pushes made with `GITHUB_TOKEN` do **not**
+trigger other workflows, so the release PR would never get its CI checks and the
+docs regeneration wouldn't run. An App installation token does trigger them.
+
+**How it's wired.** The **Release Charts** workflow mints a short-lived,
+repo-scoped token with `actions/create-github-app-token`, reading two
+**organization** secrets (so the App can be reused across repos):
+
+- `RELEASE_PLEASE_CLIENT_ID` — the App's client ID
+- `RELEASE_PLEASE_APP_PRIVATE_KEY` — the App's private key (PEM contents)
+
+**What the App needs.** It must be *installed on this repo*, and granted only:
+Contents (read & write), Pull requests (read & write), and Issues (read & write,
+for PR labels). The minted token inherits the App's permissions — it can be
+scoped to a repo but not to fewer permissions — so keep the App minimal.
+
+**Rotating the private key.** Generate a new key in the App's settings, update
+the `RELEASE_PLEASE_APP_PRIVATE_KEY` org secret, then delete the old key. GitHub
+lets multiple keys be valid at once, so this is zero-downtime.
+
+**If release-PR checks stop running,** it's almost always this token: confirm
+the org secrets still exist and are in scope for the repo, and that the App's
+key hasn't been revoked or the App uninstalled.
 
 ## Documentation (helm-docs)
 


### PR DESCRIPTION
Add a Release automation section to CONTRIBUTING covering why release-please uses a GitHub App token (GITHUB_TOKEN does not trigger downstream workflows), how it's wired (create-github-app-token + the two org secrets), the App's required permissions and install scope, how to rotate the private key, and a troubleshooting pointer. Also note node is now provided by mise.