### PR TITLE
fix(curator): make the prod resource sizing branch reachable

### DIFF
--- a/charts/curator/templates/_helpers.tpl
+++ b/charts/curator/templates/_helpers.tpl
@@ -111,13 +111,16 @@ storageClassName: {{ $storageClass | quote }}
 {{- end -}}
 
 {{/*
-Create the resource blocks based on environment sizing or allow for overrides
+Create the resource blocks based on environment sizing or allow for overrides.
+The environment values compared here must stay in sync with the `environment`
+enum in values.schema.json (dev, qa, prod) -- a comparison against a value the
+schema rejects makes the branch unreachable.
 */}}
 {{- define "curator.resources" -}}
 {{- if .Values.resources -}}
 {{- toYaml .Values.resources -}}
 {{- else -}}
-{{- if eq .Values.environment "production" -}}
+{{- if eq .Values.environment "prod" -}}
 requests:
   cpu: 1
   memory: 1Gi

--- a/charts/curator/tests/deployment_test.yaml
+++ b/charts/curator/tests/deployment_test.yaml
@@ -52,3 +52,62 @@ tests:
     asserts:
       - notExists:
           path: spec.replicas
+
+  # The sizing branches key off `environment`, whose allowed values come from
+  # values.schema.json (dev, qa, prod). These pin that agreement: a branch
+  # comparing against a value the schema rejects is unreachable and silently
+  # falls through to the small block.
+  - it: uses the production sizing when environment is prod and resources is unset
+    set:
+      image.tag: latest
+      environment: prod
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 1Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 1500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 2Gi
+
+  - it: uses the small sizing for non-prod environments
+    set:
+      image.tag: latest
+      environment: dev
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 512Mi
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 500m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 512Mi
+
+  - it: prefers an explicit resources override over the environment sizing
+    set:
+      image.tag: latest
+      environment: prod
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: 3.5
+          memory: 1Gi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 250m
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 3.5


### PR DESCRIPTION
## The bug

`curator.resources` in `_helpers.tpl` picks a sizing block by environment when a release doesn't set `resources` itself:

```gotemplate
{{- if eq .Values.environment "production" -}}
```

But `values.schema.json` restricts `environment` to `dev | qa | prod`, and the schema is enforced at render. `"production"` is a value the chart will not accept, so **the production branch was unreachable** — a prod release with no explicit `resources` silently got the small block (500m/512Mi requests and limits) instead of the intended 1 CPU / 1Gi requests and 1500m / 2Gi limits.

## Blast radius: none today

All 19 `prod-*-helmrelease.yaml` files in `iac-interworks` (plus the `.templates/` stub they're generated from) set `resources` explicitly, so every prod site today takes the override branch and never reaches this code. The fix corrects a latent default: it changes what a **future** prod site gets if it omits `resources`, and nothing about the current fleet.

## The fix

- Compare against `"prod"`, the value the schema actually permits.
- Note on the helper that the compared values have to stay in sync with the schema's `environment` enum, since that drift is what caused this.
- Add three cases to `deployment_test.yaml`: prod sizing, non-prod sizing, and an explicit `resources` override winning over both.

## Testing

Ran the suite locally with the pinned helm 4.2.3 and helm-unittest v1.1.1:

- **With the fix:** 25 tests pass across all 6 suites.
- **With the bug reintroduced** (reverting only the comparison): the new prod-sizing case fails as it should — `Expected to equal: 1 / Actual: 500m`.

Found while writing `REVIEW.md` in #77, which cites this as the reference example of schema/template drift.