### PR TITLE
fix(config): media upload paths default states

### DIFF
--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -42,10 +42,20 @@
 {{ end }}
 - name: FILESYSTEM_DRIVER
   value: {{ .Values.curator.cms.filesystemDriver | default (ternary "s3" "local" .Values.persistence.s3.enabled) }}
+{{ if .Values.curator.cms.filesystemUploadsPath }}
 - name: FILESYSTEM_UPLOADS_PATH
-  value: {{ .Values.curator.cms.filesystemUploadsPath | default (printf "https://%s.s3.amazonaws.com/uploads" .Values.persistence.s3.bucket) }}
+  value: {{ .Values.curator.cms.filesystemUploadsPath }}
+{{ else if .Values.persistence.s3.enabled }}
+- name: FILESYSTEM_UPLOADS_PATH
+  value: {{  (printf "https://%s.s3.amazonaws.com/uploads" .Values.persistence.s3.bucket) }}
+{{ end }}
+{{ if .Values.curator.cms.filesystemMediaPath }}
 - name: FILESYSTEM_MEDIA_PATH
-  value: {{ .Values.curator.cms.filesystemMediaPath | default (printf "https://%s.s3.amazonaws.com/media" .Values.persistence.s3.bucket) }}
+  value: {{ .Values.curator.cms.filesystemMediaPath }}
+{{ else if .Values.persistence.s3.enabled }}
+- name: FILESYSTEM_MEDIA_PATH
+  value: {{ (printf "https://%s.s3.amazonaws.com/media" .Values.persistence.s3.bucket) }}
+{{ end }}
 {{ if not (kindIs "invalid" .Values.curator.cms.enableCSRF) }}
 - name: ENABLE_CSRF
   value: {{ .Values.curator.cms.enableCSRF | quote }}

--- a/charts/curator/tests/env_test.yaml
+++ b/charts/curator/tests/env_test.yaml
@@ -117,13 +117,26 @@ tests:
             name: FILESYSTEM_MEDIA_PATH
             value: https://my-bucket.s3.amazonaws.com/media
   
-  - it: sets paths storage
+  - it: set custom paths for local storage
+    set:
+      curator.cms.filesystemMediaPath: /dev/real/path/media
+      curator.cms.filesystemUploadsPath: /dev/real/path/uploads
     asserts:
       - contains:
           path: spec.template.spec.containers[0].env
           content: 
             name: FILESYSTEM_DISK
             value: local
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: 
+            name: FILESYSTEM_MEDIA_PATH
+            value: /dev/real/path/media
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: 
+            name: FILESYSTEM_UPLOADS_PATH
+            value: /dev/real/path/uploads
             
 
   - it: honors explicit overrides for cache, cms, database, filesystems, mail and powerbi settings

--- a/charts/curator/tests/env_test.yaml
+++ b/charts/curator/tests/env_test.yaml
@@ -50,6 +50,14 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DB_PORT
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILESYSTEM_UPLOADS_PATH
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILESYSTEM_MEDIA_PATH
 
   - it: switches storage to s3 when persistence.s3.enabled is set, with AWS credentials from secrets
     set:

--- a/charts/curator/tests/env_test.yaml
+++ b/charts/curator/tests/env_test.yaml
@@ -100,6 +100,32 @@ tests:
                 name: aws-creds
                 key: secret-access-key
 
+  - it: uses s3 storage when only persistence is set
+    set:
+      persistence.s3.enabled: true
+      persistence.s3.bucket: my-bucket
+      persistence.s3.region: us-east-2
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILESYSTEM_UPLOADS_PATH
+            value: https://my-bucket.s3.amazonaws.com/uploads
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: FILESYSTEM_MEDIA_PATH
+            value: https://my-bucket.s3.amazonaws.com/media
+  
+  - it: sets paths storage
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content: 
+            name: FILESYSTEM_DISK
+            value: local
+            
+
   - it: honors explicit overrides for cache, cms, database, filesystems, mail and powerbi settings
     set:
       ingress.hosts:


### PR DESCRIPTION
Sets default states when s3 persistence is both set and not set to allow for non-breaking paths