### PR TITLE
feat(config): add search config for typesense

### DIFF
--- a/charts/curator/README.md
+++ b/charts/curator/README.md
@@ -66,6 +66,24 @@ A Helm chart for Curator in a Container in Kubernetes
 | curator.readinessProbe.path | string | `"/healthz"` | Endpoint the probe hits; /healthz verifies the database is reachable |
 | curator.readinessProbe.periodSeconds | int | `10` | Period to wait between checks |
 | curator.readinessProbe.timeoutSeconds | int | `15` | Timeout for probe |
+| curator.search.algolia | object | `{"idSecretRef":{"key":null,"name":null},"secretValueSecretRef":{"key":null,"name":null}}` | config for connecting to algolia |
+| curator.search.driver | string | `nil` | search engine; allowable values: database, typesense, collection, null |
+| curator.search.identify | string | `nil` | only allowed when search driver is set to algolia |
+| curator.search.prefix | string | `nil` | search prefix applied to all search index names, allows for multitenancy |
+| curator.search.queue | string | `nil` | allows for queuing of data sync |
+| curator.search.typesense | object | `{"apiKeySecretRef":{"key":null,"name":null},"connection":{"healcheckInterval":null,"retries":null,"retryInterval":null,"timeout":null},"host":null,"importAction":null,"maxResults":null,"path":null,"port":null,"protocol":null}` | config for connecting to typesense |
+| curator.search.typesense.apiKeySecretRef | object | `{"key":null,"name":null}` | api key config to authenticate to typesense |
+| curator.search.typesense.connection | object | `{"healcheckInterval":null,"retries":null,"retryInterval":null,"timeout":null}` | connection parameters |
+| curator.search.typesense.connection.healcheckInterval | string | `nil` | in seconds, time between healthcheck probes |
+| curator.search.typesense.connection.retries | string | `nil` | max number of retries before considered failed |
+| curator.search.typesense.connection.retryInterval | string | `nil` | number of retries allowed before considered failed |
+| curator.search.typesense.connection.timeout | string | `nil` | in seconds, time until considered unavailable |
+| curator.search.typesense.host | string | `nil` | typesense endpoint |
+| curator.search.typesense.importAction | string | `nil` | defines how typesense imports data |
+| curator.search.typesense.maxResults | string | `nil` | max number of results returned by typesense |
+| curator.search.typesense.path | string | `nil` | typesense path |
+| curator.search.typesense.port | string | `nil` | typesense port |
+| curator.search.typesense.protocol | string | `nil` | typesense protocol,  |
 | curator.sentry.dsn | string | `""` | Sentry Laravel DSN for error reporting |
 | curator.sentry.environment | string | `""` | Sentry Laravel environment name, defaults to the Helm release name if not set |
 | curator.session.cookie | string | `nil` |  |

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -223,9 +223,11 @@
 # No configurable items in services
 ###
 # winter/search/search.php
+{{ if .Values.curator.search.driver }}
 {{ $validSearchEngine := list "database" "typesense" }}
 {{ if not (has .Values.curator.search.driver $validSearchEngine )}}
 {{ fail (printf "Invalid search driver '%s'. Must be either database or typesense" .Values.curator.search.driver) }}
+{{ end }}
 {{ end }}
 - name: SEARCH_DRIVER
   value: {{ .Values.curator.search.driver}}

--- a/charts/curator/templates/_env.tpl
+++ b/charts/curator/templates/_env.tpl
@@ -222,6 +222,64 @@
 ###
 # No configurable items in services
 ###
+# winter/search/search.php
+{{ $validSearchEngine := list "database" "typesense" }}
+{{ if not (has .Values.curator.search.driver $validSearchEngine )}}
+{{ fail (printf "Invalid search driver '%s'. Must be either database or typesense" .Values.curator.search.driver) }}
+{{ end }}
+- name: SEARCH_DRIVER
+  value: {{ .Values.curator.search.driver}}
+- name: SEARCH_PREFIX
+  value: {{ .Values.curator.search.prefix}}
+- name: SEARCH_QUEUE
+  value: {{ .Values.curator.search.queue}}
+{{ if eq .Values.driver "algolia"}}
+- name: SEARCH_IDENTIFY
+  value: .Values.algolia.identify
+{{ with .Values.algolia.idSecretRef }}
+- name: ALGOLIA_APP_ID
+  valueFrom:
+    secretKeyRef:
+        name: {{ .name }}
+        key: {{ .key }}
+{{ end }}
+{{ with .Values.algolia.secretValueSecretRef }}
+- name: ALGOLIA_APP_SECRET
+  valueFrom:
+    secretKeyRef:
+        name: {{ .name }}
+        key: {{ .key }}
+{{ end }}
+{{ end }}
+{{ if eq .Values.curator.search.driver "typesense" }}
+{{ with .Values.curator.search.typesense.apiKeySecretRef }}
+- name: TYPESENSE_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .name }}
+      key: {{ .key }}
+{{ end }}
+- name: TYPESENSE_HOST
+  value: {{ .Values.curator.search.typesense.host }}
+- name: TYPESENSE_PORT
+  value: {{ .Values.curator.search.typesense.port | quote }}
+- name: TYPESENSE_PATH
+  value: {{ .Values.curator.search.typesense.path }}
+- name: TYPESENSE_PROTOCOL
+  value: {{ .Values.curator.search.typesense.protocol }}
+- name: TYPESENSE_CONNECTION_TIMEOUT_SECONDS
+  value: {{ .Values.curator.search.typesense.connection.timeout | quote }}
+- name: TYPESENSE_HEALTHCHECK_INTERVAL_SECONDS
+  value: {{ .Values.curator.search.typesense.connection.healthcheckInterval | quote }}
+- name: TYPESENSE_NUM_RETRIES
+  value: {{ .Values.curator.search.typesense.connection.retries | quote }}
+- name: TYPESENSE_RETRY_INTERVAL_SECONDS
+  value: {{ .Values.curator.search.typesense.connection.retryInterval | quote }}
+- name: TYPESENSE_MAX_RESULTS
+  value: {{ .Values.curator.search.typesense.maxResults | quote}}
+- name: TYPESENSE_IMPORT_ACTION
+  value: {{ .Values.curator.search.typesense.importAction }}
+{{ end }}
 # session.php
 - name: SESSION_DRIVER
   value: {{ .Values.curator.session.driver | default "database" | quote }}

--- a/charts/curator/tests/search_engine_test.yaml
+++ b/charts/curator/tests/search_engine_test.yaml
@@ -1,0 +1,104 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: test searchEngine
+templates:
+  - deployment.yaml
+release:
+  name: curator
+tests:
+  - it: errors on non-allowable setting
+    set:
+      curator.search.driver: "algolia"
+    asserts:
+      - failedTemplate:
+          errorMessage: "Invalid search driver 'algolia'. Must be either database or typesense"
+  - it: renders expected typesense values
+    set:
+      curator.search.driver: "typesense"
+      curator.search.prefix: "prefix"
+      curator.search.queue: "searchQueue"
+      curator.search.typesense.apiKeySecretRef.name: "secretName"
+      curator.search.typesense.apiKeySecretRef.key: "secretKey"
+      curator.search.typesense.host: "typesense-host"
+      curator.search.typesense.port: "8108"
+      curator.search.typesense.path: "subPath"
+      curator.search.typesense.protocol: "http"
+      curator.search.typesense.connection.timeout: "15"
+      curator.search.typesense.connection.healthcheckInterval: "30"
+      curator.search.typesense.connection.retries: "3"
+      curator.search.typesense.connection.retryInterval: "5"
+      curator.search.typesense.maxResults: "500"
+      curator.search.typesense.importAction: "upsert"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SEARCH_DRIVER
+            value: typesense
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SEARCH_PREFIX
+            value: prefix
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SEARCH_QUEUE
+            value: searchQueue
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: secretName
+                key: secretKey
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_HOST
+            value: typesense-host
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_PORT
+            value: "8108"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_PATH
+            value: subPath
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_PROTOCOL
+            value: http
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_CONNECTION_TIMEOUT_SECONDS
+            value: "15"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_HEALTHCHECK_INTERVAL_SECONDS
+            value: "30"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_NUM_RETRIES
+            value: "3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_RETRY_INTERVAL_SECONDS
+            value: "5"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_MAX_RESULTS
+            value: "500"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TYPESENSE_IMPORT_ACTION
+            value: upsert

--- a/charts/curator/values.yaml
+++ b/charts/curator/values.yaml
@@ -275,6 +275,51 @@ curator:
     cacheExpirySeconds: ~
   queue:
     connection: ~
+  search:
+    # -- search engine; allowable values: database, typesense, collection, null
+    driver: ~
+    # -- search prefix applied to all search index names, allows for multitenancy
+    prefix: ~
+    # -- allows for queuing of data sync
+    queue: ~
+    # -- only allowed when search driver is set to algolia
+    identify:
+    # -- config for connecting to algolia
+    algolia:
+      idSecretRef:
+        name: ~
+        key: ~
+      secretValueSecretRef:
+        name: ~
+        key: ~
+    # -- config for connecting to typesense
+    typesense:
+      # -- api key config to authenticate to typesense
+      apiKeySecretRef:
+        name: ~
+        key: ~
+      # -- typesense endpoint
+      host: ~
+      # -- typesense port
+      port: ~
+      # -- typesense path
+      path: ~
+      # -- typesense protocol, 
+      protocol: ~
+      # -- connection parameters
+      connection:
+        # -- in seconds, time until considered unavailable
+        timeout: ~
+        # -- in seconds, time between healthcheck probes
+        healcheckInterval: ~
+        # -- max number of retries before considered failed
+        retries: ~
+        # -- number of retries allowed before considered failed
+        retryInterval: ~
+      # -- max number of results returned by typesense
+      maxResults: ~
+      # -- defines how typesense imports data
+      importAction: ~
   session:
     driver: ~
     cookie: ~


### PR DESCRIPTION
Adds config variables to configure the new search functionality in curator. Specifically support for typesense. Algoria config was included for posterity but is unsupported at this time.